### PR TITLE
Configure Rails to Use Postgres instead of SQLite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,8 @@ end
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.3'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+# Use postgres as the database for Active Record
+gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,7 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    pg (0.21.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -213,7 +214,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     temple (0.8.0)
     thor (0.20.0)
     thread_safe (0.3.6)
@@ -254,6 +254,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  pg
   puma (~> 3.7)
   rails (~> 5.1.3)
   rspec-rails
@@ -261,7 +262,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,28 @@
-# SQLite version 3.x
-#   gem install sqlite3
+# Postgres
 #
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
+#   gem install pg
+#
+#   Ensure the Postgres gem is defined in your Gemfile
+#   gem 'pg'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: letsmeetup_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: letsmeetup_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: letsmeetup_production
+  username: letsmeetup
+  password: <%= ENV['LETSMEETUP_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
So in order for this to work properly, you have to have postgres installed and configured on your computer.

## Resources:

- Homebrew, a must-have if you're on OS X:  https://brew.sh/
- Postgres Installation: https://gist.github.com/sgnl/609557ebacd3378f3b72

**Notes regarding the instructions in the second link:**
- if you're on OS X, your config file will be `~/.bash_profile`, not `~/.zshrc`
- the `subl` part of `subl ~/.zshrc` refers to the sublime text editor. Replace that with your editor of choice.
- there might be better instructions out there, this is just the first one I found that worked.