### PR TITLE
Remove null:false constraint on Event model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 /node_modules
 /**/.DS_Store
 /public/packs-test
+.idea/

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,6 @@
 # Event for users to attend
 class Event < ApplicationRecord
   validates :name, presence: true
-  validates :time, presence: true
   validates :duration_minutes, presence: true
 
   belongs_to :location

--- a/db/migrate/20170903063631_change_column_null_in_event.rb
+++ b/db/migrate/20170903063631_change_column_null_in_event.rb
@@ -1,5 +1,5 @@
 class ChangeColumnNullInEvent < ActiveRecord::Migration[5.1]
   def change
-    change_column_null(:events, :time, true, nil)
+    change_column_null(:events, :time, true, Time.zone.now)
   end
 end

--- a/db/migrate/20170903063631_change_column_null_in_event.rb
+++ b/db/migrate/20170903063631_change_column_null_in_event.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNullInEvent < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null(:events, :time, true, nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170903064743) do
+ActiveRecord::Schema.define(version: 20170903063631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170901053411) do
+ActiveRecord::Schema.define(version: 20170903064743) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "events", force: :cascade do |t|
     t.string "name", null: false
-    t.datetime "time", null: false
+    t.datetime "time"
     t.integer "duration_minutes", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -29,8 +29,8 @@ ActiveRecord::Schema.define(version: 20170901053411) do
   end
 
   create_table "events_users", force: :cascade do |t|
-    t.integer "event_id", null: false
-    t.integer "user_id", null: false
+    t.bigint "event_id", null: false
+    t.bigint "user_id", null: false
     t.index ["event_id", "user_id"], name: "index_events_users_on_event_id_and_user_id", unique: true
     t.index ["event_id"], name: "index_events_users_on_event_id"
     t.index ["user_id"], name: "index_events_users_on_user_id"
@@ -46,8 +46,8 @@ ActiveRecord::Schema.define(version: 20170901053411) do
   end
 
   create_table "preferences", force: :cascade do |t|
-    t.integer "timeslot_id", null: false
-    t.integer "user_id", null: false
+    t.bigint "timeslot_id", null: false
+    t.bigint "user_id", null: false
     t.integer "preference_type", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 20170901053411) do
   end
 
   create_table "timeslots", force: :cascade do |t|
-    t.integer "event_id", null: false
+    t.bigint "event_id", null: false
     t.datetime "start_time", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -73,4 +73,8 @@ ActiveRecord::Schema.define(version: 20170901053411) do
   end
 
   add_foreign_key "events", "locations"
+  add_foreign_key "events_users", "events"
+  add_foreign_key "events_users", "users"
+  add_foreign_key "preferences", "timeslots"
+  add_foreign_key "timeslots", "events"
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Event, type: :model do
     expect(subject).to_not be_valid
   end
 
-  it "is invalid without a time" do
+  it "is valid without a time" do
     subject.time = nil
-    expect(subject).to_not be_valid
+    expect(subject).to be_valid
   end
 
   it "is invalid without a duration" do


### PR DESCRIPTION
There were some changes to schema.db that seemed to be from Jeremy's earlier migrations.  Are we not supposed to be checking in the schema.db changes?