### PR TITLE
Update database cleaner to fix deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :development, :test do
   gem 'guard-rspec', require: false
   gem 'factory_girl_rails'
   gem 'shoulda'
-  gem 'database_cleaner'
+  gem 'database_cleaner', '~> 1.6.1'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
-    database_cleaner (1.5.3)
+    database_cleaner (1.6.1)
     diff-lcs (1.3)
     erubi (1.6.1)
     erubis (2.7.0)
@@ -258,7 +258,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   capybara (~> 2.13)
-  database_cleaner
+  database_cleaner (~> 1.6.1)
   factory_girl_rails
   guard-rspec
   haml


### PR DESCRIPTION
Fixes issue where: "DEPRECATION WARNING: schema_migrations_table_name is deprecated and will be removed from Rails 5.2" would be printed when running tests.

Related to this issue with database cleaner: https://github.com/DatabaseCleaner/database_cleaner/issues/476