### PR TITLE
Fix issue where seed would create too many preferences

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -39,7 +39,7 @@ end
 
 USERS = User.all
 
-Event.all.each do |event|
+Event.find_each do |event|
   event.users = USERS.sample(USERS_PER_EVENT)
   TIMESLOTS_PER_EVENT.times do
     timeslot = Timeslot.create!(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,7 +44,7 @@ Event.all.each do |event|
   TIMESLOTS_PER_EVENT.times do
     timeslot = Timeslot.create!(
       event_id: event.id,
-      start_time: Faker::Time.forward
+      start_time: Faker::Time.forward(30)
     )
     timeslot.preferences.each do |preference|
       preference.preference_type = rand(4)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,57 +13,42 @@ TIMESLOTS_PER_EVENT = 10
 USERS_PER_EVENT = 5
 
 NUM_USERS.times do
-  User.create!({
+  User.create!(
     name: Faker::Name.unique.name,
     email: Faker::Internet.unique.email,
     password: Faker::Internet.password
-  })
+  )
 end
 
 NUM_LOCATIONS.times do
-  Location.create!({
+  Location.create!(
     name: Faker::Address.unique.community,
     address: Faker::Address.unique.street_address
-  })
+  )
 end
 
 LOCATIONS = Location.all
 
 NUM_EVENTS.times do
-  event = Event.create!({
+  event = Event.create!(
     name: Faker::Pokemon.unique.name,
     duration_minutes: rand(300),
     location_id: LOCATIONS.sample.id
-  })
+  )
+end
 
-  indices = []
+USERS = User.all
 
-  (6 * USERS_PER_EVENT).times do
-    indices << rand(NUM_USERS - 1)
-  end
-
-  all_users = User.all
-  event_users = indices.uniq[0...USERS_PER_EVENT].map { |index| all_users[index] }
-
-  event_users.each do |user|
-    EventsUser.create!({
-      event_id: event.id,
-      user_id: user.id
-    })
-  end
-
+Event.all.each do |event|
+  event.users = USERS.sample(USERS_PER_EVENT)
   TIMESLOTS_PER_EVENT.times do
-    timeslot = Timeslot.create!({
+    timeslot = Timeslot.create!(
       event_id: event.id,
-      start_time: Faker::Time.forward(30)
-    })
-
-    event_users.each do |user|
-      Preference.create!({
-        timeslot_id: timeslot.id,
-        user_id: user.id,
-        preference_type: rand(5)
-      })
+      start_time: Faker::Time.forward
+    )
+    timeslot.preferences.each do |preference|
+      preference.preference_type = rand(4)
+      preference.save
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,7 +47,7 @@ Event.all.each do |event|
       start_time: Faker::Time.forward(30)
     )
     timeslot.preferences.each do |preference|
-      preference.preference_type = rand(4)
+      preference.preference_type = rand(5)
       preference.save
     end
   end


### PR DESCRIPTION
The after_create in timeslot automatically creates a preference for every user, so this seed file would result in multiple preferences for the same timeslot.